### PR TITLE
Trim any newlines that can cause an unhandled server fault

### DIFF
--- a/server/php/api/originKeys.php
+++ b/server/php/api/originKeys.php
@@ -5,8 +5,9 @@
  * /originKeys Documentation: https://docs.adyen.com/api-explorer/#/CheckoutUtility/v1/originKeys
  */
 function getOriginKey() {
-    $apikey = getenv('CHECKOUT_APIKEY');
-    $merchantAccount = getenv('MERCHANT_ACCOUNT');
+    // Trim control chars that might sneak in
+    $apikey = trim(getenv('CHECKOUT_APIKEY'));
+    $merchantAccount = trim(getenv('MERCHANT_ACCOUNT'));
     $url = "https://checkout-test.adyen.com/v1/originKeys";
 
     // Get the current domain

--- a/server/php/api/paymentMethods.php
+++ b/server/php/api/paymentMethods.php
@@ -16,8 +16,9 @@ function getPaymentMethods() {
         $request = array();
     }
 
-    $apikey = getenv('CHECKOUT_APIKEY');
-    $merchantAccount = getenv('MERCHANT_ACCOUNT');
+    // Trim control chars that might sneak in
+    $apikey = trim(getenv('CHECKOUT_APIKEY'));
+    $merchantAccount = trim(getenv('MERCHANT_ACCOUNT'));
     $url = "https://checkout-test.adyen.com/v50/paymentMethods";
 
     $data = [

--- a/server/php/api/payments.php
+++ b/server/php/api/payments.php
@@ -15,8 +15,9 @@ function initiatePayment() {
         $request = array();
     }
 
-    $apikey = getenv('CHECKOUT_APIKEY');
-    $merchantAccount = getenv('MERCHANT_ACCOUNT');
+    // Trim control chars that might sneak in
+    $apikey = trim(getenv('CHECKOUT_APIKEY'));
+    $merchantAccount = trim(getenv('MERCHANT_ACCOUNT'));
     $url = "https://checkout-test.adyen.com/v50/payments";
 
     $data = [


### PR DESCRIPTION
I've been trying for a few days to get the component demo working, but the AJAX endpoints on the Adyen servers were failing with generic 400 Apache crashes. These were not in JSON so I wonder if they are unhandled exceptions.

I found that my `.env` var file was to blame - they had somehow acquired NL or CR characters on the end. I wonder if it was something to do with Windows, Git using the wrong `core.autocrlf` setting, or the handling of text files in Docker, or Docker volumes on Windows...

Either way, it seems that (a) it is possible for env vars to incorrectly contain control characters, and (b) the servers currently crash and do not respond with JSON. This fix alleviates that on the client side for this demo.

I will also raise the issue with tech support, so that a fix can be considered on the server side.