### PR TITLE
Fixing links to Adyen docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ After deploying, to use Sessions Drop-in, add your ```CLIENT_KEY``` to the confi
 
 ## Documentation
 
-For the complete integration guide, refer to the [Web Components documentation](https://docs.adyen.com/checkout/components-web/).
+For the complete integration guide, refer to the [Web Components documentation](https://docs.adyen.com/online-payments/web-components).
 
 ## Other sample projects
 

--- a/src/ach/index.html
+++ b/src/ach/index.html
@@ -30,7 +30,7 @@
                     To make a payment, use a valid ABA routing number: <a href="https://www.usbanklocations.com/u-s-bank-routing-number.shtml" target="_blank">bank routing numbers</a>.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/bancontact/index.html
+++ b/src/bancontact/index.html
@@ -27,7 +27,7 @@
                     Check the Source Code to see the full implementation.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/bcmc/index.html
+++ b/src/bcmc/index.html
@@ -27,7 +27,7 @@
                     Check the Source Code to see the full implementation.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/boleto/index.html
+++ b/src/boleto/index.html
@@ -35,7 +35,7 @@
                     Check the Source Code to see the full implementation.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/card/index.html
+++ b/src/card/index.html
@@ -30,7 +30,7 @@
                     To make a payment, use our <a href="https://docs.adyen.com/developers/development-resources/test-cards/test-card-numbers" target="_blank">test card numbers</a>.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/customcard/index.html
+++ b/src/customcard/index.html
@@ -78,7 +78,7 @@
                                               target="_blank">test card numbers</a>.
             </p>
             <p>
-                For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout
+                For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout
                 Components documentation</a>.
             </p>
         </div>

--- a/src/dropin/index.html
+++ b/src/dropin/index.html
@@ -34,7 +34,7 @@
                         target="_blank">test card numbers</a>.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/drop-in-web/"
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-drop-in/"
                         target="_blank">Drop-in documentation</a>.
                 </p>
             </div>

--- a/src/googlepay/index.html
+++ b/src/googlepay/index.html
@@ -28,7 +28,7 @@
                     Check the Source Code to see the full implementation.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/ideal/index.html
+++ b/src/ideal/index.html
@@ -26,7 +26,7 @@
                     Check the Source Code to see the full implementation.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -65,7 +65,7 @@
 
         <div class="info">
             <p>
-                For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
             </p>
         </div>
     </div>

--- a/src/multibanco/index.html
+++ b/src/multibanco/index.html
@@ -27,7 +27,7 @@
                     Check the Source Code to see the full implementation.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/sepa/index.html
+++ b/src/sepa/index.html
@@ -30,7 +30,7 @@
                     To make a payment, use our <a href="https://docs.adyen.com/developers/development-resources/test-cards/test-card-numbers#sepadirectdebit" target="_blank">SEPA Direct Debit test credentials</a>.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/sessions/index.html
+++ b/src/sessions/index.html
@@ -31,7 +31,7 @@
                     To make a payment, use our <a href="https://docs.adyen.com/developers/development-resources/test-cards/test-card-numbers" target="_blank">test card numbers</a>.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/drop-in-web/" target="_blank">Drop-in documentation</a>.
+                    For more information, please refer to the <a href="" target="_blank">Drop-in documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/sessions/index.html
+++ b/src/sessions/index.html
@@ -31,7 +31,7 @@
                     To make a payment, use our <a href="https://docs.adyen.com/developers/development-resources/test-cards/test-card-numbers" target="_blank">test card numbers</a>.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="" target="_blank">Drop-in documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-drop-in/" target="_blank">Drop-in documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/swish/index.html
+++ b/src/swish/index.html
@@ -26,7 +26,7 @@
                     Check the Source Code to see the full implementation.
                 </p>
                 <p>
-                    For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.
+                    For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.
                 </p>
             </div>
         </div>

--- a/src/wechatpay/index.html
+++ b/src/wechatpay/index.html
@@ -24,7 +24,7 @@
 
             <div class="info">
                 <p>Check the Source Code to see the full implementation.</p>
-                <p>For more information, please refer to the <a href="https://docs.adyen.com/checkout/components-web/" target="_blank">Checkout Components documentation</a>.</p>
+                <p>For more information, please refer to the <a href="https://docs.adyen.com/online-payments/web-components" target="_blank">Checkout Components documentation</a>.</p>
             </div>
         </div>
 


### PR DESCRIPTION
Fixed links to Adyen's public documentation pages for Web Dropin and Web Components integration guides. 